### PR TITLE
Fix: 'package/appimage/setup-appimagetool' action

### DIFF
--- a/.github/workflows/check-package-actions.yml
+++ b/.github/workflows/check-package-actions.yml
@@ -47,17 +47,15 @@ jobs:
     - name: Run 'package/appimage/setup-appimagetool' action
       id: setup-appimagetool
       uses: ./package/appimage/setup-appimagetool
-      with:
-        appimagetool-runtime: 'all'
 
     - name: Test 'package/appimage/setup-appimagetool' action
       shell: bash
       run: |
 
-        if ( ! command -v "${{ env.GITHUB_ACTION_APPIMAGETOOL_FILE }}" ); then
+        if ( ! command -v "${{ env.FINEBITS_GITHUB_ACTION_APPIMAGETOOL_FILE }}" ); then
           echo "::error::'package/appimage/setup-appimagetool' test failed. env.GITHUB_ACTION_APPIMAGETOOL_FILE is '${{ env.GITHUB_ACTION_APPIMAGETOOL_FILE }}'. The command not found"
           exit 1
-        elif [ ! -d "${{ env.GITHUB_ACTION_APPIMAGETOOL_DIR }}" ]; then
+        elif [ ! -d "${{ env.FINEBITS_GITHUB_ACTION_APPIMAGETOOL_DIR }}" ]; then
           echo "::error::'package/appimage/setup-appimagetool' test failed. env.GITHUB_ACTION_APPIMAGETOOL_DIR is '${{ env.GITHUB_ACTION_APPIMAGETOOL_DIR }}'. The directory does not exist"
           exit 2
         else

--- a/package/appimage/pack/action.yml
+++ b/package/appimage/pack/action.yml
@@ -62,13 +62,13 @@ runs:
           exit 1
         fi
 
-        if ( ! command -v "${{ env.GITHUB_ACTION_APPIMAGETOOL_FILE }}" ); then
-          echo "::error::'${{ env.GITHUB_ACTION_APPIMAGETOOL_FILE }}' command not found"
+        if ( ! command -v "${{ env.FINEBITS_GITHUB_ACTION_APPIMAGETOOL_FILE }}" ); then
+          echo "::error::'${{ env.FINEBITS_GITHUB_ACTION_APPIMAGETOOL_FILE }}' command not found"
           exit 2
         fi
 
-        if [ ! -d "${{ env.GITHUB_ACTION_APPIMAGETOOL_DIR }}" ]; then
-          echo "::error::'${{ env.GITHUB_ACTION_APPIMAGETOOL_DIR }}' directory does not exist"
+        if [ ! -d "${{ env.FINEBITS_GITHUB_ACTION_APPIMAGETOOL_DIR }}" ]; then
+          echo "::error::'${{ env.FINEBITS_GITHUB_ACTION_APPIMAGETOOL_DIR }}' directory does not exist"
           exit 3
         fi
 
@@ -77,8 +77,8 @@ runs:
       shell: bash
       run: |
 
-        appimagetool="${{ env.GITHUB_ACTION_APPIMAGETOOL_FILE }}"
-        appimagetool_dir="${{ env.GITHUB_ACTION_APPIMAGETOOL_DIR }}"
+        appimagetool="${{ env.FINEBITS_GITHUB_ACTION_APPIMAGETOOL_FILE }}"
+        appimagetool_dir="${{ env.FINEBITS_GITHUB_ACTION_APPIMAGETOOL_DIR }}"
         output_dir="${{ inputs.package-output-dir }}"
         package_app_dir="${{ inputs.package-app-dir }}"
 
@@ -127,15 +127,17 @@ runs:
 
         echo "Packing..."
 
-        ("${appimagetool_realpath}" --runtime-file="${runtime_realpath}" "${package_app_dir_realpath}")
+        echo "$("${appimagetool_realpath}" --runtime-file="${runtime_realpath}" "${package_app_dir_realpath}")"
 
         cd "$here"
 
         package=$(find . -path "$tmp_dir/*.AppImage" -print | head -n 1)
         package_name=$(basename -- "$package")
 
+        chmod a+x "$package"
+
         mkdir -p "$output_dir"
-        cp "$package" "$output_dir"
+        mv "$package" "$output_dir"
 
         echo "AppImage package is '$output_dir/$package_name'"
         echo "appimage-package=$output_dir/$package_name" >> $GITHUB_OUTPUT

--- a/package/appimage/setup-appimagetool/action.yml
+++ b/package/appimage/setup-appimagetool/action.yml
@@ -69,7 +69,7 @@ runs:
         echo "FINEBITS_GITHUB_ACTION_APPIMAGETOOL_FILE=$appimagetool_file" >> $GITHUB_ENV
         
 
-    - name: Setup the Runtimes
+    - name: Setup Runtimes
       shell: bash
       run: |
         urls=("https://github.com/AppImage/type2-runtime/releases/download/continuous/runtime-x86_64"
@@ -78,14 +78,16 @@ runs:
               "https://github.com/AppImage/type2-runtime/releases/download/continuous/runtime-i686")
         appimagetool_dir="${{ steps.prepare-appimagetool.outputs.directory }}"
 
+        echo "Downloading runtimes..."
+
         for url in "${urls[@]}"
         do
-          name=${url##*/}
+          name="${url##*/}"
           file="$appimagetool_dir/$name"
           wget --quiet --output-document="$file" "$url"
         done
 
-    - name: Setup the Static Tools
+    - name: Setup Static Tools
       shell: bash
       run: |
         urls=("https://github.com/probonopd/static-tools/releases/download/continuous/appstreamcli-x86_64"
@@ -99,10 +101,12 @@ runs:
               "https://github.com/probonopd/static-tools/releases/download/continuous/zsyncmake-x86_64")
         appimagetool_dir="${{ steps.prepare-appimagetool.outputs.directory }}"
 
+        echo "Downloading static toos..."
+
         for url in "${urls[@]}"
         do
-          name=${url##*/}
-          name=${name%%-*}"
+          name="${url##*/}"
+          name="${name%-*}"
           file="$appimagetool_dir/$name"
           wget --quiet --output-document="$file" "$url"
           chmod a+x "$file"

--- a/package/appimage/setup-appimagetool/action.yml
+++ b/package/appimage/setup-appimagetool/action.yml
@@ -101,7 +101,7 @@ runs:
               "https://github.com/probonopd/static-tools/releases/download/continuous/zsyncmake-x86_64")
         appimagetool_dir="${{ steps.prepare-appimagetool.outputs.directory }}"
 
-        echo "Downloading static toos..."
+        echo "Downloading static tools..."
 
         for url in "${urls[@]}"
         do

--- a/package/appimage/setup-appimagetool/action.yml
+++ b/package/appimage/setup-appimagetool/action.yml
@@ -19,23 +19,13 @@
 name: Setup appimagetool
 
 description: | 
-  To setup appimagetool and its runtimes. Look at - https://github.com/AppImage/AppImageKit#appimagetool-usage
-  As a result, the 'GITHUB_ACTION_APPIMAGETOOL_FILE' environment variable contains the full name of the appimagetool-x86_64.AppImage file
-  and the 'GITHUB_ACTION_APPIMAGETOOL_DIR' environment variable contains the full path of the appimagetool-x86_64.AppImage directory
-
-inputs:
-  appimagetool-runtime:
-    description: 'To setup additional runtimes'
-    type: choice
-    options:
-    - all
-    - aarch64
-    - armhf
-    - i686
-    - x86_64
-    - none
-    required: false
-    default: all
+  To setup appimagetool, its runtimes and static tools.
+  As a result, the 'FINEBITS_GITHUB_ACTION_APPIMAGETOOL_FILE' environment variable contains the full name of the appimagetool-x86_64.AppImage file,
+  the 'PATH' and 'FINEBITS_GITHUB_ACTION_APPIMAGETOOL_DIR' environment variable contains the full path of the appimagetool-x86_64.AppImage directory.
+  Look at - https://github.com/AppImage/appimagetool;
+            https://github.com/AppImage/type2-runtime;
+            https://github.com/probonopd/static-tools; 
+            https://github.com/AppImage/AppImageKit#appimagetool-usage;
 
 runs:
   using: "composite"
@@ -56,64 +46,65 @@ runs:
         appimagetool_dir="./.appimagetool/$(uuidgen)"
         mkdir -p "$appimagetool_dir"
 
+        appimagetool_dir=$(readlink -f "$(pwd)/$dir")
+        echo "$appimagetool_dir" >> $GITHUB_PATH
         echo "directory=$appimagetool_dir" >> $GITHUB_OUTPUT
+        
 
     - name: Setup appimagetool
       id: setup-appimagetool
       shell: bash
       run: |
-        echo "Install libfuse2"
-        sudo add-apt-repository universe && sudo apt install libfuse2
+        url="https://github.com/AppImage/appimagetool/releases/download/continuous/appimagetool-x86_64.AppImage"
+        appimagetool_dir="${{ steps.prepare-appimagetool.outputs.directory }}"
+        appimagetool_file="$appimagetool_dir/appimagetool-x86_64.AppImage"
 
-        url="https://github.com/AppImage/AppImageKit/releases/download/continuous/appimagetool-x86_64.AppImage"
-        dir="${{ steps.prepare-appimagetool.outputs.directory }}"
+        echo "Download appimagetool to '$appimagetool_dir'"
+        wget --quiet --output-document="$appimagetool_file" "$url"
 
-        echo "Download appimagetool to '$(pwd)/$dir'"
-        wget --quiet --directory-prefix="$dir" "$url"
-
-        appimagetool=$(find . -path "$dir/appimagetool-*.AppImage" -print | head -n 1)
-
-        appimagetool_file=$(readlink -f "$appimagetool")
         echo "Setup appimagetool: $appimagetool_file"
         chmod a+x "$appimagetool_file"
 
-        appimagetool_dir=$(readlink -f "$(pwd)/$dir")
+        echo "FINEBITS_GITHUB_ACTION_APPIMAGETOOL_DIR=$appimagetool_dir" >> $GITHUB_ENV
+        echo "FINEBITS_GITHUB_ACTION_APPIMAGETOOL_FILE=$appimagetool_file" >> $GITHUB_ENV
+        
 
-        echo "GITHUB_ACTION_APPIMAGETOOL_DIR=$appimagetool_dir" >> $GITHUB_ENV
-        echo "GITHUB_ACTION_APPIMAGETOOL_FILE=$appimagetool_file" >> $GITHUB_ENV
-
-    - name: Setup x86_64 Runtime
-      if: inputs.appimagetool-runtime == 'x86_64' || inputs.appimagetool-runtime == 'all' 
+    - name: Setup the Runtimes
       shell: bash
       run: |
-        url="https://github.com/AppImage/AppImageKit/releases/download/continuous/runtime-x86_64"
-        dir="${{ steps.prepare-appimagetool.outputs.directory }}"
+        urls=("https://github.com/AppImage/type2-runtime/releases/download/continuous/runtime-x86_64"
+              "https://github.com/AppImage/type2-runtime/releases/download/continuous/runtime-aarch64"
+              "https://github.com/AppImage/type2-runtime/releases/download/continuous/runtime-armhf"
+              "https://github.com/AppImage/type2-runtime/releases/download/continuous/runtime-i686")
+        appimagetool_dir="${{ steps.prepare-appimagetool.outputs.directory }}"
 
-        wget --quiet --directory-prefix="$dir" "$url"
+        for url in "${urls[@]}"
+        do
+          name=${url##*/}
+          file="$appimagetool_dir/$name"
+          wget --quiet --output-document="$file" "$url"
+        done
 
-    - name: Setup aarch64 Runtime
-      if: inputs.appimagetool-runtime == 'aarch64' || inputs.appimagetool-runtime == 'all' 
+    - name: Setup the Static Tools
       shell: bash
       run: |
-        url="https://github.com/AppImage/AppImageKit/releases/download/continuous/runtime-aarch64"
-        dir="${{ steps.prepare-appimagetool.outputs.directory }}"
+        urls=("https://github.com/probonopd/static-tools/releases/download/continuous/appstreamcli-x86_64"
+              "https://github.com/probonopd/static-tools/releases/download/continuous/bsdtar-x86_64"
+              "https://github.com/probonopd/static-tools/releases/download/continuous/desktop-file-install-x86_64"
+              "https://github.com/probonopd/static-tools/releases/download/continuous/desktop-file-validate-x86_64"
+              "https://github.com/probonopd/static-tools/releases/download/continuous/mksquashfs-x86_64"
+              "https://github.com/probonopd/static-tools/releases/download/continuous/patchelf-x86_64"
+              "https://github.com/probonopd/static-tools/releases/download/continuous/unsquashfs-x86_64"
+              "https://github.com/probonopd/static-tools/releases/download/continuous/update-desktop-database-x86_64"
+              "https://github.com/probonopd/static-tools/releases/download/continuous/zsyncmake-x86_64")
+        appimagetool_dir="${{ steps.prepare-appimagetool.outputs.directory }}"
 
-        wget --quiet --directory-prefix="$dir" "$url"
-
-    - name: Setup i686 (i383) Runtime
-      if: inputs.appimagetool-runtime == 'i686' || inputs.appimagetool-runtime == 'all' 
-      shell: bash
-      run: |
-        url="https://github.com/AppImage/AppImageKit/releases/download/continuous/runtime-i686"
-        dir="${{ steps.prepare-appimagetool.outputs.directory }}"
-
-        wget --quiet --directory-prefix="$dir" "$url"
-
-    - name: Setup armhf Runtime
-      if: inputs.appimagetool-runtime == 'armhf' || inputs.appimagetool-runtime == 'all' 
-      shell: bash
-      run: |
-        url="https://github.com/AppImage/AppImageKit/releases/download/continuous/runtime-armhf"
-        dir="${{ steps.prepare-appimagetool.outputs.directory }}"
-
-        wget --quiet --directory-prefix="$dir" "$url"
+        for url in "${urls[@]}"
+        do
+          name=${url##*/}
+          name=${name%%-*}"
+          file="$appimagetool_dir/$name"
+          wget --quiet --output-document="$file" "$url"
+          chmod a+x "$file"
+        done
+   

--- a/package/appimage/setup-appimagetool/action.yml
+++ b/package/appimage/setup-appimagetool/action.yml
@@ -49,7 +49,6 @@ runs:
         appimagetool_dir=$(readlink -f "$(pwd)/$dir")
         echo "$appimagetool_dir" >> $GITHUB_PATH
         echo "directory=$appimagetool_dir" >> $GITHUB_OUTPUT
-        
 
     - name: Setup appimagetool
       id: setup-appimagetool
@@ -67,7 +66,6 @@ runs:
 
         echo "FINEBITS_GITHUB_ACTION_APPIMAGETOOL_DIR=$appimagetool_dir" >> $GITHUB_ENV
         echo "FINEBITS_GITHUB_ACTION_APPIMAGETOOL_FILE=$appimagetool_file" >> $GITHUB_ENV
-        
 
     - name: Setup Runtimes
       shell: bash
@@ -111,4 +109,3 @@ runs:
           wget --quiet --output-document="$file" "$url"
           chmod a+x "$file"
         done
-   


### PR DESCRIPTION
- The runtime is linked statically, libfuse2 is no longer required on the target system.